### PR TITLE
Add StringComparison implementation to StringParser

### DIFF
--- a/src/Warpstone.Tests/Parsers/BasicParsersTests.cs
+++ b/src/Warpstone.Tests/Parsers/BasicParsersTests.cs
@@ -529,6 +529,18 @@ namespace Warpstone.Tests.Parsers
         }
 
         /// <summary>
+        /// Checks that the expected parser works correctly.
+        /// </summary>
+        [Fact]
+        public static void StringComparisonCorrect()
+        {
+            IParser<string> parser = String("test-string", System.StringComparison.InvariantCultureIgnoreCase);
+            IParseResult<string> result = parser.TryParse("TeSt-StRiNg");
+            AssertThat(result.Success).IsTrue();
+            AssertThat(result.Value).IsSameAs("test-string");
+        }
+
+        /// <summary>
         /// Checks that transformation exceptions are handled correctly.
         /// </summary>
         [Fact]

--- a/src/Warpstone/Parsers/BasicParsers.cs
+++ b/src/Warpstone/Parsers/BasicParsers.cs
@@ -42,6 +42,15 @@ namespace Warpstone.Parsers
             => new StringParser(str);
 
         /// <summary>
+        /// Creates a parser that parses a string, using the specified string comparison method.
+        /// </summary>
+        /// <param name="str">The string to parse.</param>
+        /// <param name="stringComparison">The string comparison method to use.</param>
+        /// <returns>A parser parsing a string.</returns>
+        public static IParser<string> String(string str, StringComparison stringComparison)
+            => new StringParser(str, stringComparison);
+
+        /// <summary>
         /// Creates a parser parsing the given character.
         /// </summary>
         /// <param name="c">The character to parse.</param>

--- a/src/Warpstone/Parsers/InternalParsers/StringParser.cs
+++ b/src/Warpstone/Parsers/InternalParsers/StringParser.cs
@@ -1,4 +1,6 @@
-﻿namespace Warpstone.Parsers.InternalParsers
+﻿using System;
+
+namespace Warpstone.Parsers.InternalParsers
 {
     /// <summary>
     /// Parser which parser a given string.
@@ -10,13 +12,22 @@
         /// Initializes a new instance of the <see cref="StringParser"/> class.
         /// </summary>
         /// <param name="str">The string to look for.</param>
-        internal StringParser(string str)
-            => String = str;
+        /// <param name="stringComparison">The string comparison method to use.</param>
+        internal StringParser(string str, StringComparison? stringComparison = null)
+        {
+            String = str;
+            StringComparison = stringComparison;
+        }
 
         /// <summary>
         /// Gets the regular expression.
         /// </summary>
         internal string String { get; }
+
+        /// <summary>
+        /// Gets the string comparison method.
+        /// </summary>
+        internal StringComparison? StringComparison { get; }
 
         /// <inheritdoc/>
         public override IParseResult<string> TryParse(string input, int position)
@@ -36,15 +47,22 @@
                 return false;
             }
 
-            for (int i = 0; i < String.Length; i++)
+            if (StringComparison.HasValue)
             {
-                if (String[i] != input[position + i])
-                {
-                    return false;
-                }
+                return String.Equals(input.Substring(position, String.Length), StringComparison.Value);
             }
+            else
+            {
+                for (int i = 0; i < String.Length; i++)
+                {
+                    if (String[i] != input[position + i])
+                    {
+                        return false;
+                    }
+                }
 
-            return true;
+                return true;
+            }
         }
     }
 }


### PR DESCRIPTION
I would like to parse case-insensitive strings. So I added a [`System.StringComparison`](https://docs.microsoft.com/en-us/dotnet/api/system.stringcomparison?view=net-5.0) option to the `String` parser function.

I assume the character-by-character version is there becasue it's faster than a string/substring comparison, so I left that in if no string comparison method is specified.