### PR TITLE
Allow the delimiter and terminator types to be different

### DIFF
--- a/src/Warpstone/Parsers/BasicParsers.cs
+++ b/src/Warpstone/Parsers/BasicParsers.cs
@@ -85,12 +85,13 @@ namespace Warpstone.Parsers
         /// </summary>
         /// <typeparam name="T1">The type of results collected.</typeparam>
         /// <typeparam name="T2">The type of delimiters.</typeparam>
+        /// <typeparam name="T3">The type of the terminator.</typeparam>
         /// <param name="parser">The parser to apply multiple times.</param>
         /// <param name="delimiter">The delimiter seperating the different elements.</param>
         /// <param name="count">The exact number of matches.</param>
         /// <param name="terminator">The terminator indicating the end of the sequence.</param>
         /// <returns>A parser applying the given parser multiple times.</returns>
-        public static IParser<IList<T1>> Multiple<T1, T2>(IParser<T1> parser, IParser<T2> delimiter, int count, IParser<T2> terminator)
+        public static IParser<IList<T1>> Multiple<T1, T2, T3>(IParser<T1> parser, IParser<T2> delimiter, int count, IParser<T3> terminator)
             => Multiple(parser, delimiter, count, count, terminator);
 
         /// <summary>
@@ -109,7 +110,7 @@ namespace Warpstone.Parsers
         /// Creates a parser applying the given parser multiple times and collects all results.
         /// </summary>
         /// <typeparam name="T1">The type of results collected.</typeparam>
-        /// <typeparam name="T2">The type of delimiters.</typeparam>
+        /// <typeparam name="T2">The type of the terminator.</typeparam>
         /// <param name="parser">The parser to apply multiple times.</param>
         /// <param name="min">The minimum number of matches.</param>
         /// <param name="max">The maximum number of matches.</param>
@@ -134,13 +135,14 @@ namespace Warpstone.Parsers
         /// </summary>
         /// <typeparam name="T1">The type of results collected.</typeparam>
         /// <typeparam name="T2">The type of delimiters.</typeparam>
+        /// <typeparam name="T3">The type of the terminator.</typeparam>
         /// <param name="parser">The parser to apply multiple times.</param>
         /// <param name="delimiter">The delimiter seperating the different elements.</param>
         /// <param name="min">The minimum number of matches.</param>
         /// <param name="max">The maximum number of matches.</param>
         /// <param name="terminator">The terminator indicating the end of the sequence.</param>
         /// <returns>A parser applying the given parser multiple times.</returns>
-        public static IParser<IList<T1>> Multiple<T1, T2>(IParser<T1> parser, IParser<T2> delimiter, int min, int max, IParser<T2> terminator)
+        public static IParser<IList<T1>> Multiple<T1, T2, T3>(IParser<T1> parser, IParser<T2> delimiter, int min, int max, IParser<T3> terminator)
         {
             if (min < 0)
             {
@@ -195,12 +197,13 @@ namespace Warpstone.Parsers
         /// </summary>
         /// <typeparam name="T1">The type of results collected.</typeparam>
         /// <typeparam name="T2">The type of delimiters.</typeparam>
+        /// <typeparam name="T3">The type of the terminator.</typeparam>
         /// <param name="parser">The parser to apply multiple times.</param>
         /// <param name="delimiter">The delimiter seperating the different elements.</param>
         /// <param name="count">The exact number of matches.</param>
         /// <param name="terminator">The terminator indicating the end of the sequence.</param>
         /// <returns>A parser applying the given parser multiple times.</returns>
-        public static IParser<IList<T1>> Multiple<T1, T2>(IParser<T1> parser, IParser<T2> delimiter, ulong count, IParser<T2> terminator)
+        public static IParser<IList<T1>> Multiple<T1, T2, T3>(IParser<T1> parser, IParser<T2> delimiter, ulong count, IParser<T3> terminator)
             => Multiple(parser, delimiter, count, count, terminator);
 
         /// <summary>
@@ -219,7 +222,7 @@ namespace Warpstone.Parsers
         /// Creates a parser applying the given parser multiple times and collects all results.
         /// </summary>
         /// <typeparam name="T1">The type of results collected.</typeparam>
-        /// <typeparam name="T2">The type of delimiters.</typeparam>
+        /// <typeparam name="T2">The type of the terminator.</typeparam>
         /// <param name="parser">The parser to apply multiple times.</param>
         /// <param name="min">The minimum number of matches.</param>
         /// <param name="max">The maximum number of matches.</param>
@@ -244,20 +247,21 @@ namespace Warpstone.Parsers
         /// </summary>
         /// <typeparam name="T1">The type of results collected.</typeparam>
         /// <typeparam name="T2">The type of delimiters.</typeparam>
+        /// <typeparam name="T3">The type of the terminator.</typeparam>
         /// <param name="parser">The parser to apply multiple times.</param>
         /// <param name="delimiter">The delimiter seperating the different elements.</param>
         /// <param name="min">The minimum number of matches.</param>
         /// <param name="max">The maximum number of matches.</param>
         /// <param name="terminator">The terminator indicating the end of the sequence.</param>
         /// <returns>A parser applying the given parser multiple times.</returns>
-        public static IParser<IList<T1>> Multiple<T1, T2>(IParser<T1> parser, IParser<T2> delimiter, ulong min, ulong max, IParser<T2> terminator)
+        public static IParser<IList<T1>> Multiple<T1, T2, T3>(IParser<T1> parser, IParser<T2> delimiter, ulong min, ulong max, IParser<T3> terminator)
         {
             if (max < min)
             {
                 throw new ArgumentException($"Value of '{nameof(max)}' needs to be larger than or equal to value of '{nameof(min)}'.", nameof(max));
             }
 
-            return new MultipleParser<T1, T2>(parser, delimiter, terminator, min, max);
+            return new MultipleParser<T1, T2, T3>(parser, delimiter, terminator, min, max);
         }
 
         /// <summary>
@@ -287,11 +291,12 @@ namespace Warpstone.Parsers
         /// </summary>
         /// <typeparam name="T1">The type of results collected.</typeparam>
         /// <typeparam name="T2">The type of delimiters.</typeparam>
+        /// <typeparam name="T3">The type of the terminator.</typeparam>
         /// <param name="parser">The parser to apply multiple times.</param>
         /// <param name="delimiter">The delimiter seperating the different elements.</param>
         /// <param name="terminator">The terminator indicating the end of the sequence.</param>
         /// <returns>A parser applying the given parser multiple times.</returns>
-        public static IParser<IList<T1>> Many<T1, T2>(IParser<T1> parser, IParser<T2> delimiter, IParser<T2> terminator)
+        public static IParser<IList<T1>> Many<T1, T2, T3>(IParser<T1> parser, IParser<T2> delimiter, IParser<T3> terminator)
               => Multiple(parser, delimiter, 0, ulong.MaxValue, terminator);
 
         /// <summary>
@@ -319,11 +324,12 @@ namespace Warpstone.Parsers
         /// </summary>
         /// <typeparam name="T1">The type of results collected.</typeparam>
         /// <typeparam name="T2">The type of delimiters.</typeparam>
+        /// <typeparam name="T3">The type of the terminator.</typeparam>
         /// <param name="parser">The parser to apply multiple times.</param>
         /// <param name="delimiter">The delimiter seperating the different elements.</param>
         /// <param name="terminator">The terminator indicating the end of the sequence.</param>
         /// <returns>A parser applying the given parser at least once and collecting all results.</returns>
-        public static IParser<IList<T1>> OneOrMore<T1, T2>(IParser<T1> parser, IParser<T2> delimiter, IParser<T2> terminator)
+        public static IParser<IList<T1>> OneOrMore<T1, T2, T3>(IParser<T1> parser, IParser<T2> delimiter, IParser<T3> terminator)
             => Multiple(parser, delimiter, 1, ulong.MaxValue, terminator);
 
         /// <summary>

--- a/src/Warpstone/Parsers/InternalParsers/MultipleParser.cs
+++ b/src/Warpstone/Parsers/InternalParsers/MultipleParser.cs
@@ -7,17 +7,18 @@ namespace Warpstone.Parsers.InternalParsers
     /// </summary>
     /// <typeparam name="T1">The result type of the wrapped parser.</typeparam>
     /// <typeparam name="T2">The result type of the delimiter parser.</typeparam>
-    internal class MultipleParser<T1, T2> : Parser<IList<T1>>
+    /// <typeparam name="T3">The result type of the terminator parser.</typeparam>
+    internal class MultipleParser<T1, T2, T3> : Parser<IList<T1>>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="MultipleParser{T1, T2}"/> class.
+        /// Initializes a new instance of the <see cref="MultipleParser{T1, T2, T3}"/> class.
         /// </summary>
         /// <param name="parser">The wrapped parser.</param>
         /// <param name="delimiter">The delimiter parser.</param>
         /// <param name="min">The minimum number of parsed items.</param>
         /// <param name="max">The maximum number of parsed items.</param>
         /// <param name="terminator">The terminator parser.</param>
-        internal MultipleParser(IParser<T1> parser, IParser<T2> delimiter, IParser<T2> terminator, ulong min, ulong max)
+        internal MultipleParser(IParser<T1> parser, IParser<T2> delimiter, IParser<T3> terminator, ulong min, ulong max)
         {
             Parser = parser;
             DelimiterParser = delimiter;
@@ -39,7 +40,7 @@ namespace Warpstone.Parsers.InternalParsers
         /// <summary>
         /// Gets the terminator parser.
         /// </summary>
-        internal IParser<T2> TerminatorParser { get; }
+        internal IParser<T3> TerminatorParser { get; }
 
         /// <summary>
         /// Gets the minimum number of parsed items.
@@ -112,7 +113,7 @@ namespace Warpstone.Parsers.InternalParsers
                 elements.Add(result.Value);
             }
 
-            IParseResult<T2> terminatorResult = TerminatorParser.TryParse(input, newPosition);
+            IParseResult<T3> terminatorResult = TerminatorParser.TryParse(input, newPosition);
             if (!terminatorResult.Success)
             {
                 if (error == null)


### PR DESCRIPTION
This change allows the types of the delimiter and terminator for the `Multiple` parser family to differ. This is accomplished by adding an extra type parameter where necessary.

Some documentation descriptions for the `T2` parameter are also changed from the delimiter type to the terminator type, where appropriate.