### PR TITLE
Introduction of the notion of a (source) span

### DIFF
--- a/src/Warpstone.Tests/Text/SourceSpan_specs.cs
+++ b/src/Warpstone.Tests/Text/SourceSpan_specs.cs
@@ -1,0 +1,210 @@
+using Warpstone.Text;
+
+namespace Text.SourceSpan_specs;
+
+public class IndexOf
+{
+    [Fact]
+    public void null_if_not_found()
+    {
+        SourceSpan span = Source.From("ABC");
+        span.IndexOf('D').Should().BeNull();
+    }
+
+    [Fact]
+    public void null_if_only_found_before()
+    {
+        SourceSpan span = Source.From("ABC");
+        span++;
+        span.IndexOf('A').Should().BeNull();
+    }
+
+    [Fact]
+    public void null_if_only_found_after()
+    {
+        SourceSpan span = Source.From("ABC");
+        span = span.Trim(new(0, 2));
+        span.IndexOf('C').Should().BeNull();
+    }
+
+    [Fact]
+    public void TextSpan_of_length_1()
+    {
+        SourceSpan span = Source.From("ABCEFGHIJKLMNOPQR");
+        span++;
+        var text = span.IndexOf('Q');
+        text.Should().Be(new TextSpan(15, 1));
+    }
+}
+
+public class Match
+{
+    [Fact]
+    public void null_if_not_found()
+    {
+        SourceSpan span = Source.From("ABC");
+        span.Match(@"\d").Should().BeNull();
+    }
+
+    [Fact]
+    public void null_if_only_found_before()
+    {
+        SourceSpan span = Source.From("1BC");
+        span++;
+        span.Match(@"\d").Should().BeNull();
+    }
+
+    [Fact]
+    public void null_if_only_found_after()
+    {
+        SourceSpan span = Source.From("AB3");
+        span = span.Trim(new(0, 2));
+        span.Match(@"\d").Should().BeNull();
+    }
+
+    [Fact]
+    public void TextSpan_of_length_matches()
+    {
+        SourceSpan span = Source.From("ABCEFGHI123MNOPQR");
+        span++;
+        var text = span.Match(@"\d+");
+        text.Should().Be(new TextSpan(8, 3));
+    }
+
+    [Fact]
+    public void TextSpan_of_length_zero_on_successful_empty_match()
+    {
+        SourceSpan span = Source.From("ABCEFGHI123MNOPQR");
+        span++;
+        var text = span.Match(@"\s*");
+        text.Should().Be(new TextSpan(1, 0));
+    }
+}
+
+public class StartsWith
+{
+    public class Chars
+    {
+        [Fact]
+        public void null_if_false()
+        {
+            SourceSpan span = Source.From("ABC");
+            span.StartsWith('D').Should().BeNull();
+        }
+
+        [Fact]
+        public void null_if_character_before_span()
+        {
+            SourceSpan span = Source.From("ABC");
+            span++;
+            span.StartsWith('A').Should().BeNull();
+        }
+
+        [Fact]
+        public void TextSpan_of_length_1()
+        {
+            SourceSpan span = Source.From("ABCEFGHIJKLMNOPQR");
+            span++;
+            var text = span.StartsWith('B');
+            text.Should().Be(new TextSpan(1, 1));
+        }
+    }
+
+    public class Strings
+    {
+        [Fact]
+        public void null_if_false()
+        {
+            SourceSpan span = Source.From("ABC");
+            span.StartsWith("D").Should().BeNull();
+        }
+
+        [Fact]
+        public void null_if_too_long()
+        {
+            SourceSpan span = Source.From("ABC");
+            span.StartsWith("ABCD").Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData("A")]
+        [InlineData("AB")]
+        public void null_if_character_before_span(string value)
+        {
+            SourceSpan span = Source.From("ABC");
+            span++;
+            span.StartsWith(value).Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData("B", 1)]
+        [InlineData("BC", 2)]
+        [InlineData("BCD", 3)]
+        public void TextSpan_of_match(string value, int length)
+        {
+            SourceSpan span = Source.From("ABCDEFGHIJKLMNOPQR");
+            span++;
+            var text = span.StartsWith(value);
+            text.Should().Be(new TextSpan(1, length));
+        }
+    }
+}
+
+public class Predicate
+{
+    [Fact]
+    public void null_if_not_found()
+    {
+        SourceSpan span = Source.From("ABC");
+        var text = span.Predicate(char.IsDigit);
+        text.Should().BeNull();
+    }
+
+    [Fact]
+    public void null_if_only_found_before()
+    {
+        SourceSpan span = Source.From("1BC");
+        span++;
+        span.Predicate(char.IsDigit).Should().BeNull();
+    }
+
+    [Fact]
+    public void null_if_only_found_after()
+    {
+        SourceSpan span = Source.From("AB3");
+        span = span.Trim(new(0, 2));
+        span.Predicate(char.IsDigit).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("1234")]
+    [InlineData("1234ABC")]
+    public void TextSpan_of_length_matches(string source)
+    {
+        SourceSpan span = Source.From(source);
+        span++;
+        var text = span.Predicate(char.IsDigit);
+        text.Should().Be(new TextSpan(1, 3));
+    }
+}
+
+public class First
+{
+    [Theory]
+    [InlineData('A', 0)]
+    [InlineData('B', 1)]
+    [InlineData('C', 2)]
+    public void returns_first(char first, int skip)
+    {
+        SourceSpan span = Source.From("ABCD");
+        span = span.Skip(skip);
+        span[0].Should().Be(first);
+    }
+
+    [Fact]
+    public void throws_for_empty()
+    {
+        SourceSpan span = Source.From(string.Empty);
+        span.Invoking(s => s.First).Should().Throw<IndexOutOfRangeException>();
+    }
+}

--- a/src/Warpstone/CompatibilitySuppressions.xml
+++ b/src/Warpstone/CompatibilitySuppressions.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Suppression>
@@ -463,6 +463,27 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Warpstone.Text.Source</Target>
+    <Left>lib/netstandard2.0/Warpstone.dll</Left>
+    <Right>lib/netstandard2.0/Warpstone.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Warpstone.Text.SourceSpan</Target>
+    <Left>lib/netstandard2.0/Warpstone.dll</Left>
+    <Right>lib/netstandard2.0/Warpstone.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Warpstone.Text.TextSpan</Target>
+    <Left>lib/netstandard2.0/Warpstone.dll</Left>
+    <Right>lib/netstandard2.0/Warpstone.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Warpstone.TransformationError</Target>
     <Left>lib/netstandard2.0/Warpstone.dll</Left>
     <Right>lib/netstandard2.0/Warpstone.dll</Right>
@@ -661,6 +682,12 @@
   <Suppression>
     <DiagnosticId>CP0016</DiagnosticId>
     <Target>M:Warpstone.Parsers.Regex(System.String,System.Text.RegularExpressions.RegexOptions)$0:[T:System.Diagnostics.CodeAnalysis.StringSyntaxAttribute]</Target>
+    <Left>lib/net6.0/Warpstone.dll</Left>
+    <Right>lib/net7.0/Warpstone.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:Warpstone.Text.SourceSpan.Match(System.String)$0:[T:System.Diagnostics.CodeAnalysis.StringSyntaxAttribute]</Target>
     <Left>lib/net6.0/Warpstone.dll</Left>
     <Right>lib/net7.0/Warpstone.dll</Right>
   </Suppression>
@@ -1710,6 +1737,24 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:Warpstone.Text.SourceSpan.Equals(System.Object):[T:System.Runtime.CompilerServices.NullableContextAttribute]</Target>
+    <Left>lib/net7.0/Warpstone.dll</Left>
+    <Right>lib/net8.0/Warpstone.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:Warpstone.Text.TextSpan.Equals(System.Object):[T:System.Runtime.CompilerServices.NullableContextAttribute]</Target>
+    <Left>lib/net7.0/Warpstone.dll</Left>
+    <Right>lib/net8.0/Warpstone.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:Warpstone.Text.TextSpan.ToString:[T:System.Runtime.CompilerServices.NullableContextAttribute]</Target>
+    <Left>lib/net7.0/Warpstone.dll</Left>
+    <Right>lib/net8.0/Warpstone.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
     <Target>M:Warpstone.UnsafeParseResult.#ctor(System.Int32,System.Int32,System.Object):[T:System.Runtime.CompilerServices.NullableContextAttribute]</Target>
     <Left>lib/net7.0/Warpstone.dll</Left>
     <Right>lib/net8.0/Warpstone.dll</Right>
@@ -2155,6 +2200,30 @@
   <Suppression>
     <DiagnosticId>CP0016</DiagnosticId>
     <Target>T:Warpstone.RecursiveParseContext`1&lt;0&gt;:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
+    <Left>lib/net7.0/Warpstone.dll</Left>
+    <Right>lib/net8.0/Warpstone.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:Warpstone.Text.Source:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
+    <Left>lib/net7.0/Warpstone.dll</Left>
+    <Right>lib/net8.0/Warpstone.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:Warpstone.Text.Source:[T:System.Runtime.CompilerServices.NullableContextAttribute]</Target>
+    <Left>lib/net7.0/Warpstone.dll</Left>
+    <Right>lib/net8.0/Warpstone.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:Warpstone.Text.SourceSpan:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
+    <Left>lib/net7.0/Warpstone.dll</Left>
+    <Right>lib/net8.0/Warpstone.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:Warpstone.Text.SourceSpan:[T:System.Runtime.CompilerServices.NullableContextAttribute]</Target>
     <Left>lib/net7.0/Warpstone.dll</Left>
     <Right>lib/net8.0/Warpstone.dll</Right>
   </Suppression>

--- a/src/Warpstone/Text/Source.cs
+++ b/src/Warpstone/Text/Source.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Diagnostics.Contracts;
+
+namespace Warpstone.Text;
+
+/// <summary>Represents the full source text.</summary>
+public readonly struct Source
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Source"/> struct with the specified text.
+    /// </summary>
+    /// <param name="text">
+    /// The text of the source.
+    /// </param>
+    private Source(string text)
+    {
+        Text = text ?? string.Empty;
+        TextSpan = new TextSpan(0, Text.Length);
+    }
+
+    /// <summary>The text of the source.</summary>
+    public readonly string Text;
+
+    /// <summary>The text span of the source.</summary>
+    public readonly TextSpan TextSpan;
+
+    /// <summary>The length of the full source.</summary>
+    public int Length => Text.Length;
+
+    /// <summary>A character at the specified position of the source.</summary>
+    /// <param name="index">The index of the character.</param>
+    public char this[int index] => Text[index];
+
+    /// <inheritdoc />
+    public override string ToString() => Text;
+
+    /// <summary>Gets the string representation of the source text within the specified span.</summary>
+    /// <param name="span">The span of text to extract.</param>
+    /// <returns>
+    /// a substring of the source text.
+    /// </returns>
+    [Pure]
+    public string ToString(TextSpan span) => Text.Substring(span.Start, span.Length);
+
+    /// <summary>Implicitly casts to a <see cref="SourceSpan"/>.</summary>
+    /// <param name="source">The source to cast.</param>
+    public static implicit operator SourceSpan(Source source) => new(source, source.TextSpan);
+
+    /// <summary>Creates a new source.</summary>
+    /// <param name="text">The text of the source.</param>
+    /// <returns>
+    /// A new source.
+    /// </returns>
+    [Pure]
+    public static Source From(string text) => new(text);
+}

--- a/src/Warpstone/Text/SourceSpan.cs
+++ b/src/Warpstone/Text/SourceSpan.cs
@@ -91,13 +91,9 @@ public readonly struct SourceSpan(Source source, TextSpan textSpan) : IEquatable
     /// </returns>
     [Pure]
     public TextSpan? StartsWith(char ch)
-    {
-        var result = !TextSpan.IsEmpty && Source.Text[TextSpan.Start] == ch
-            ? new TextSpan(TextSpan.Start, 1)
-            : NoMatch;
-
-        return result;
-    }
+        => !TextSpan.IsEmpty && Source.Text[TextSpan.Start] == ch
+        ? new TextSpan(TextSpan.Start, 1)
+        : NoMatch;
 
     /// <summary>Indicates that the text span starts with the specified string.</summary>
     /// <param name="str">
@@ -108,26 +104,9 @@ public readonly struct SourceSpan(Source source, TextSpan textSpan) : IEquatable
     /// </returns>
     [Pure]
     public TextSpan? StartsWith(string str)
-    {
-        if (TextSpan.Length >= str.Length)
-        {
-            var pos = TextSpan.Start;
-
-            for (var i = 0; i < str.Length; i++)
-            {
-                if (Source[pos++] != str[i])
-                {
-                    return NoMatch;
-                }
-            }
-
-            return new TextSpan(TextSpan.Start, str.Length);
-        }
-        else
-        {
-            return NoMatch;
-        }
-    }
+        => AsSpan().StartsWith(str.AsSpan())
+        ? new TextSpan(TextSpan.Start, str.Length)
+        : NoMatch;
 
     /// <summary>Matches the predicate.</summary>
     /// <param name="match">

--- a/src/Warpstone/Text/SourceSpan.cs
+++ b/src/Warpstone/Text/SourceSpan.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
+using System.Text.RegularExpressions;
+
+namespace Warpstone.Text;
+
+/// <summary>Represents a span of a source text.</summary>
+/// <param name="source">
+/// The full source text.
+/// </param>
+/// <param name="textSpan">
+/// The (selected) span of the source text.
+/// </param>
+public readonly struct SourceSpan(Source source, TextSpan textSpan) : IEquatable<SourceSpan>
+{
+    /// <remarks>Syntactic sugar that allows the use of NoMatch over null.</remarks>
+    private static readonly TextSpan? NoMatch = null;
+
+    /// <summary>The underlying source.</summary>
+    public readonly Source Source = source;
+
+    /// <summary>The (selected) text span.</summary>
+    public readonly TextSpan TextSpan = textSpan;
+
+    /// <summary>Gets the first character of the source span.</summary>
+    public char First => Source[Start];
+
+    /// <summary>The (selected) source text.</summary>
+    public string Text => Source.ToString(TextSpan);
+
+    /// <summary>A character at the specified position of the source.</summary>
+    /// <param name="index">The index of the character.</param>
+    public char this[int index] => Source.Text[Start + index];
+
+    /// <summary>The start position.</summary>
+    public int Start => TextSpan.Start;
+
+    /// <summary>The end position.</summary>
+    public int End => TextSpan.End;
+
+    /// <summary>The length of the span.</summary>
+    public int Length => TextSpan.Length;
+
+    /// <summary>Indicates if the span is empty.</summary>
+    public bool IsEmpty => TextSpan.IsEmpty;
+
+    /// <summary>Indicates if the span is not empty.</summary>
+    public bool HasValue => !TextSpan.IsEmpty;
+
+    /// <summary>Exposes the text as <see cref="ReadOnlySpan{T}"/>.</summary>
+    /// <returns>
+    /// An read-only span of characters.
+    /// </returns>
+    [Pure]
+    public ReadOnlySpan<char> AsSpan() => Source.Text.AsSpan(TextSpan.Start, TextSpan.Length);
+
+    /// <summary>Trims the source span.</summary>
+    /// <param name="span">
+    /// The span to trim to.
+    /// </param>
+    /// <returns>
+    /// A trimmed source span.
+    /// </returns>
+    public SourceSpan Trim(TextSpan span) => new(Source, span);
+
+    /// <summary>Takes the number of specified characters from the start of this source span.</summary>
+    /// <param name="length">The length of the source span.</param>
+    /// <returns>
+    /// A trimmed source span.
+    /// </returns>
+    [Pure]
+    public SourceSpan Take(int length) => new(Source, new(Start, length));
+
+    /// <summary>Trims the source span from the left.</summary>
+    /// <param name="left">
+    /// The number of characters to trim.
+    /// </param>
+    /// <returns>
+    /// A trimmed source span.
+    /// </returns>
+    [Pure]
+    public SourceSpan Skip(int left) => new(Source, new(Start + left, Length - left));
+
+    /// <summary>Indicates that the text span starts with the specified character.</summary>
+    /// <param name="ch">
+    /// The character to match.
+    /// </param>
+    /// <returns>
+    /// Null if no match, otherwise the matching text span.
+    /// </returns>
+    [Pure]
+    public TextSpan? StartsWith(char ch)
+    {
+        var result = !TextSpan.IsEmpty && Source.Text[TextSpan.Start] == ch
+            ? new TextSpan(TextSpan.Start, 1)
+            : NoMatch;
+
+        return result;
+    }
+
+    /// <summary>Indicates that the text span starts with the specified string.</summary>
+    /// <param name="str">
+    /// The string to match.
+    /// </param>
+    /// <returns>
+    /// Null if no match, otherwise the matching text span.
+    /// </returns>
+    [Pure]
+    public TextSpan? StartsWith(string str)
+    {
+        if (TextSpan.Length >= str.Length)
+        {
+            var pos = TextSpan.Start;
+
+            for (var i = 0; i < str.Length; i++)
+            {
+                if (Source[pos++] != str[i])
+                {
+                    return NoMatch;
+                }
+            }
+
+            return new TextSpan(TextSpan.Start, str.Length);
+        }
+        else
+        {
+            return NoMatch;
+        }
+    }
+
+    /// <summary>Matches the predicate.</summary>
+    /// <param name="match">
+    /// The required match.
+    /// </param>
+    /// <returns>
+    /// Null if no match, otherwise the matching text span.
+    /// </returns>
+    [Pure]
+    public TextSpan? Predicate(Predicate<char> match)
+    {
+        if (IsEmpty)
+        {
+            return NoMatch;
+        }
+
+        var len = -1;
+        var i = Start;
+
+        while (++len < Length)
+        {
+            if (!match(Source[i++]))
+            {
+                return (len == 0)
+                    ? NoMatch
+                    : new(TextSpan.Start, len);
+            }
+        }
+
+        return TextSpan;
+    }
+
+    /// <inheritdoc cref="Match(Regex)" />
+    [Pure]
+    public TextSpan? Match([StringSyntax(StringSyntaxAttribute.Regex)] string pattern) => Match(new Regex(pattern, RegexOptions.CultureInvariant));
+
+    /// <summary>Reports a <see cref="Text.TextSpan"/> indicating the position of the match.</summary>
+    /// <param name="pattern">The regular expression pattern to match.</param>
+    /// <returns>
+    /// Returns null if the character was not found.
+    /// </returns>
+    [Pure]
+    public TextSpan? Match(Regex pattern)
+        => pattern.Match(Source.Text, TextSpan.Start, TextSpan.Length) is { Success: true } match
+        ? new TextSpan(match.Index, match.Length)
+        : NoMatch;
+
+    /// <summary>Reports a <see cref="Text.TextSpan"/> indicating the position of the character.</summary>
+    /// <param name="ch">The character to get the index of.</param>
+    /// <returns>
+    /// Returns null if the character was not found.
+    /// </returns>
+    [Pure]
+    public TextSpan? IndexOf(char ch)
+    {
+        var index = Source.Text.IndexOf(ch, Start, Length);
+        return index == -1
+            ? NoMatch
+            : new(index, 1);
+    }
+
+    /// <inheritdoc />
+    [Pure]
+    public override string ToString() => Text;
+
+    /// <inheritdoc />
+    [Pure]
+    public override bool Equals(object? obj) => obj is SourceSpan other && Equals(other);
+
+    /// <inheritdoc />
+    [Pure]
+    public bool Equals(SourceSpan other)
+        => TextSpan == other.TextSpan
+        && Source.Text == other.Text;
+
+    /// <inheritdoc />
+    [Pure]
+    public override int GetHashCode() => TextSpan.GetHashCode();
+
+    /// <summary>Returns true if left and right are equal.</summary>
+    /// <param name="left">
+    /// Left operator.
+    /// </param>
+    /// <param name="right">
+    /// Right operator.
+    /// </param>
+    public static bool operator ==(SourceSpan left, SourceSpan right) => left.Equals(right);
+
+    /// <summary>Returns true if left and right are different.</summary>
+    /// <param name="left">
+    /// Left operator.
+    /// </param>
+    /// <param name="right">
+    /// Right operator.
+    /// </param>
+    public static bool operator !=(SourceSpan left, SourceSpan right) => !(left == right);
+
+    /// <summary>Trims the first character of the source span.</summary>
+    /// <param name="span">The source span to trim.</param>
+    public static SourceSpan operator ++(SourceSpan span) => span.Skip(1);
+}

--- a/src/Warpstone/Text/TextSpan.cs
+++ b/src/Warpstone/Text/TextSpan.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Warpstone.Text;
+
+/// <summary>Represents of a span of text.</summary>
+[DataContract]
+public readonly struct TextSpan : IEquatable<TextSpan>, IComparable<TextSpan>
+{
+    /// <summary>Initializes a new instance of the <see cref="TextSpan"/> struct.</summary>
+    /// <param name="start">Start position of the span.</param>
+    /// <param name="length">Length of the span.</param>
+    public TextSpan(int start, int length)
+    {
+        if (start < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(start));
+        }
+
+        if (start + length < start)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length));
+        }
+
+        Start = start;
+        Length = length;
+    }
+
+    /// <summary>
+    /// Start point of the span.
+    /// </summary>
+    [DataMember(Order = 0)]
+    public int Start { get; }
+
+    /// <summary>
+    /// End of the span.
+    /// </summary>
+    public int End => Start + Length;
+
+    /// <summary>
+    /// Length of the span.
+    /// </summary>
+    [DataMember(Order = 1)]
+    public int Length { get; }
+
+    /// <summary>
+    /// Determines whether or not the span is empty.
+    /// </summary>
+    public bool IsEmpty => Length == 0;
+
+    /// <summary>
+    /// Determines if two instances of <see cref="TextSpan"/> are the same.
+    /// </summary>
+    /// <param name="left">Left instance to compare.</param>
+    /// <param name="right">Right instance to compare.</param>
+    public static bool operator ==(TextSpan left, TextSpan right) => left.Equals(right);
+
+    /// <summary>
+    /// Determines if two instances of <see cref="TextSpan"/> are different.
+    /// </summary>
+    /// <param name="left">Left instance to compare.</param>
+    /// <param name="right">Right instance to compare.</param>
+    public static bool operator !=(TextSpan left, TextSpan right) => !left.Equals(right);
+
+    /// <inheritdoc />
+    public bool Equals(TextSpan other)
+        => Start == other.Start
+        && Length == other.Length;
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+        => obj is TextSpan span && Equals(span);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => Start ^ (Length << 16);
+
+    /// <inheritdoc />
+    public override string ToString() => $"[{Start}..{End})";
+
+    /// <inheritdoc />
+    public int CompareTo(TextSpan other)
+    {
+        var diff = Start - other.Start;
+        return diff is 0
+            ? Length - other.Length
+            : diff;
+    }
+}


### PR DESCRIPTION
To prevent (unnecessary) string allocations which can be huge performance bottleneck, it can be useful (I've experimented with this in the past, with significant speed improvements) to cut the source in chunks without to have to create sub strings per chunk.

For now the reference is a simple read-only `Source` struct that is a wrapper around  a `string`. The `SourceSpan` is both a reference to the `Source` and a `TextSpan` (that has the same structure and implementation as Microsoft's `TextSpan`) representing the start index of the span and its length.

It contains a set of trimming functions (`Trim`, `Skip`, and `Take`) returning a new `TextSpan` and match functions (`StartsWith`, `Predicate`, `Matches`, and `IndexOf`) which return a `TextSpan?` where null indicates no match, and the span represents the match. The first set is useful to create spans for tokens to match and the remaining span to parse, and the others help defining the tokens to match.

What do you think?